### PR TITLE
Update repository URL and license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project requires the following dependencies:
 
 To install this project, follow these steps:
 
-1. Clone the repository: `git clone https://github.com/your-username/interface-gestion-de-voyages-Qt-Cpp.git`
+1. Clone the repository: `git clone https://github.com/aliammari1/QtVoyager.git`
 2. Open the `mainwindow.cpp` file in Qt Creator
 3. Build and run the project
 
@@ -65,4 +65,4 @@ For more information on how to contribute to this project, please see our [contr
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for more information.
+Read the `LICENSE` file for more information.

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ For more information on how to contribute to this project, please see our [contr
 
 ## License
 
-Read the `LICENSE` file for more information.
+This project is licensed under a custom **COMMERCIAL USE LICENSE**, which includes restrictions on commercial use. Please refer to the `LICENSE` file for the full terms and conditions.


### PR DESCRIPTION
## Summary by Sourcery

Update README to reflect the current GitHub repository URL and license wording.

Documentation:
- Update README cloning instructions to point to the new GitHub repository URL.
- Adjust README license section to reference the LICENSE file without specifying a particular license.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README with the correct clone URL (github.com/aliammari1/QtVoyager) and clarified that the project uses a custom Commercial Use License with restrictions. See the LICENSE file for full terms.

<sup>Written for commit 180e225b9297e1e820bfeb61dca7cebffe6edf70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the project repository URL in the Getting Started section to point to the new repository for accurate setup instructions.
  * Replaced the previous MIT license summary with a custom COMMERCIAL USE LICENSE note and directed readers to the LICENSE file for full terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->