### PR TITLE
docs: add open-source growth plan

### DIFF
--- a/docs/OPEN_SOURCE_GROWTH_PLAN.md
+++ b/docs/OPEN_SOURCE_GROWTH_PLAN.md
@@ -1,0 +1,40 @@
+# Open Source Growth Plan
+
+This plan converts the repository review into a practical backlog for QtVoyager.
+
+## Quick wins
+
+- Add screenshots or GIFs showing the travel dashboard, search, sorting, charting, RFID flow, and plane animation.
+- Add a Qt Test suite for search, sorting, average-cost calculation, and file/data loading.
+- Add a GitHub Actions build that installs Qt and compiles the project.
+- Add clang-format and clang-tidy configuration for consistent C++ style.
+- Document sample data and expected folder structure.
+- Add release packaging notes for Qt Installer Framework.
+
+## Bugs and bad practices to watch
+
+- Raw pointer ownership and QObject lifetime issues.
+- Business logic coupled directly to UI widgets.
+- Missing error handling for data files and RFID input.
+- Chart calculations that are not independently testable.
+- Platform-specific path assumptions.
+
+## Star growth strategy
+
+1. Add visual screenshots and a demo dataset.
+2. Add a one-command build path for each supported platform.
+3. Publish release artifacts so users can try the app quickly.
+4. Add `good first issue` tasks for translations, sample data, and UI polish.
+5. Share the project in Qt and C++ communities.
+
+## Trending-library opportunities
+
+- Use Polars in a companion analysis script for travel-cost analytics.
+- Use MarkItDown-style export to generate Markdown itineraries or reports.
+- Use AI-assisted chart recommendations for travel trends and cost summaries.
+
+## Suggested next PRs
+
+- Add `tests/` with Qt Test coverage for non-UI logic.
+- Add `docs/ARCHITECTURE.md` explaining UI, data loading, and charting.
+- Add a CI workflow that validates the build.


### PR DESCRIPTION
Adds a repository-specific implementation plan for the QtVoyager review: quick wins, bug-prone areas, star-growth strategy, and trending-library opportunities.

This is a safe first implementation slice that does not change runtime behavior.

## Summary by Sourcery

Documentation:
- Add OPEN_SOURCE_GROWTH_PLAN.md describing quick wins, risk areas, star-growth strategy, trending-library ideas, and suggested follow-up PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an open-source growth plan for QtVoyager in docs/OPEN_SOURCE_GROWTH_PLAN.md. It outlines quick wins, risk areas, a star-growth strategy, trending-library opportunities, and follow-up PRs; no runtime changes.

<sup>Written for commit 79553292124bfa56b3e5994fd437f000e38a3e09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

